### PR TITLE
Issue36 aca hcc count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,11 +164,11 @@ cython_debug/
 # be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
 # and can be added to the global gitignore or merged into this file.
 .vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
-!.vscode/*.code-snippets
+# !.vscode/settings.json
+# !.vscode/tasks.json
+# !.vscode/launch.json
+# !.vscode/extensions.json
+# !.vscode/*.code-snippets
 
 # Local History for Visual Studio Code
 .history/

--- a/src/risk_adjustment_model/commercial_model.py
+++ b/src/risk_adjustment_model/commercial_model.py
@@ -254,9 +254,14 @@ class CommercialModel(BaseModel):
             categories, dropped_hierarchy_categories = self._apply_hierarchies(
                 categories
             )
-            categories = self._determine_interactions(categories, beneficiary)
             categories, dropped_group_categories = self._apply_groups(
                 categories, beneficiary
+            )
+            # Count is based on categories and groups, so interactions occur after
+            # groups, however some interactions are based on categories dropped by
+            # groups, so the dropped categories are also passed in
+            categories = self._determine_interactions(
+                categories, beneficiary, dropped_group_categories
             )
 
             # Add the dropped categories to their own list to return in results
@@ -729,7 +734,10 @@ class CommercialModel(BaseModel):
         return demographic_category
 
     def _determine_interactions(
-        self, categories: List[Type[Category]], beneficiary: Type[CommercialBeneficiary]
+        self,
+        categories: List[Type[Category]],
+        beneficiary: Type[CommercialBeneficiary],
+        dropped_group_categories: List[Type[Category]],
     ) -> List[Type[Category]]:
         """
         Determines disease interactions based on provided Category objects and beneficiary information.

--- a/src/risk_adjustment_model/commercial_model.py
+++ b/src/risk_adjustment_model/commercial_model.py
@@ -178,10 +178,11 @@ class CommercialModel(BaseModel):
             if diagnosis_codes:
                 dx_categories = self._get_dx_categories(diagnosis_codes, beneficiary)
                 mapper_categories.extend(dx_categories)
-            if ndc_codes:
+            # Only Adults get RXCs
+            if ndc_codes and beneficiary.risk_model_age_group == "Adult":
                 ndc_categories = self._get_ndc_categories(ndc_codes)
                 mapper_categories.extend(ndc_categories)
-            if proc_codes:
+            if proc_codes and beneficiary.risk_model_age_group == "Adult":
                 proc_categories = self._get_proc_categories(proc_codes)
                 mapper_categories.extend(proc_categories)
 

--- a/src/risk_adjustment_model/v07.py
+++ b/src/risk_adjustment_model/v07.py
@@ -1351,6 +1351,7 @@ class CommercialModelV07(CommercialModel):
             in the category_list.
             - If the infant is 1 year old, the maturity status is set to "Age1" regardless of the categories.
             - If no relevant categories are present in the category_list, the maturity status defaults to "Age1".
+              In this situation, the beneficiary risk_model_age is set to 1 for alignment as well.
         """
         maturity_status = None
 
@@ -1388,6 +1389,7 @@ class CommercialModelV07(CommercialModel):
                 ]
             ):
                 maturity_status = "Age1"
+                beneficiary.risk_model_age = 1
 
         return maturity_status
 

--- a/src/risk_adjustment_model/v07.py
+++ b/src/risk_adjustment_model/v07.py
@@ -1208,7 +1208,10 @@ class CommercialModelV07(CommercialModel):
             return ["HHS_HCC021"]
 
     def _determine_interactions(
-        self, categories: List[Type[Category]], beneficiary: Type[CommercialBeneficiary]
+        self,
+        categories: List[Type[Category]],
+        beneficiary: Type[CommercialBeneficiary],
+        dropped_group_categories: List[Type[Category]],
     ) -> List[Type[Category]]:
         """
         Determines disease interactions based on provided Category objects and beneficiary information.
@@ -1217,9 +1220,15 @@ class CommercialModelV07(CommercialModel):
         Args:
             categories (List[Type[Category]]): List of Category objects representing disease categories.
             beneficiary (Type[CommercialBeneficiary]): Instance of CommercialBeneficiary representing the beneficiary information.
+            dropped_group_categories (List[Type[Category]]): List of Category objects of the HCCs dropped by groups.
 
         Returns:
             List[Type[Category]]: List of Category objects representing the disease interactions.
+
+        Notes:
+            The way the SAS code works is applying the group categories before determine count categories. However, some of the
+            interactions with RXC rely on HCCs that can get dropped as part of a group. Thus, the dropped_group_categories
+            are passed in as well and considered.
         """
         category_list = [
             category.category
@@ -1244,6 +1253,12 @@ class CommercialModelV07(CommercialModel):
                 severe_illness, transplant, category_count
             )
         else:
+            # For adults, the category_list needs to be extended to include dropped
+            # group categories
+            category_list.extend(
+                [category.category for category in dropped_group_categories]
+            )
+
             interaction_dict = self._determine_adult_interactions(
                 category_list, severe_illness, transplant, category_count, beneficiary
             )
@@ -1710,9 +1725,11 @@ class CommercialModelV07(CommercialModel):
                 - transplant (bool): True if the beneficiary has undergone a transplant, otherwise False.
 
         Notes:
-            The DIY documentation uses a mixture of both groups and categories. This is translated into categories only.
-            Comments below might indicate which group the category belongs to, but should not be considered a "source of truth".
-            That would be the "group_definition.json"
+            The DIY documentation uses a mixture of both groups and categories. The underlying categories of the groups are
+            also included in the list as a group can be added or removed for a given model year but the underlying
+            HCCs are still valid. For example, HCC 18 and HCC 183 were their own standalone categories in 2023, however in 2024
+            they are now part of G24. So by including HCC 18, HCC 183, and G24 in the below lists, the code will work for both
+            2023 and 2024.
         """
         severe_illness = any(
             category in category_list
@@ -1721,7 +1738,6 @@ class CommercialModelV07(CommercialModel):
                 "HHS_HCC003",
                 "HHS_HCC004",
                 "HHS_HCC006",
-                "HHS_HCC018",
                 "HHS_HCC023",
                 "HHS_HCC034",
                 "HHS_HCC041",
@@ -1733,34 +1749,41 @@ class CommercialModelV07(CommercialModel):
                 # G13
                 "HHS_HCC126",
                 "HHS_HCC127",
+                "G13",
                 # G14
                 "HHS_HCC128",
                 "HHS_HCC129",
+                "G14",
                 ##
                 "HHS_HCC135",
                 "HHS_HCC145",
                 "HHS_HCC156",
                 "HHS_HCC158",
                 "HHS_HCC163",
-                "HHS_HCC183",
                 "HHS_HCC218",
                 "HHS_HCC223",
                 "HHS_HCC251",
+                # G24
+                "HHS_HCC018",
+                "HHS_HCC183",
+                "G24",
             ]
         )
         transplant = any(
             category in category_list
             for category in [
-                "HHS_HCC018",
                 "HHS_HCC034",
                 "HHS_HCC041",
                 # G14
                 "HHS_HCC128",
                 "HHS_HCC129",
-                ##
+                "G14",
                 "HHS_HCC158",
-                "HHS_HCC183",
                 "HHS_HCC251",
+                # G24
+                "HHS_HCC018",
+                "HHS_HCC183",
+                "G24",
             ]
         )
 

--- a/tests/test_commercial_model_v07.py
+++ b/tests/test_commercial_model_v07.py
@@ -521,6 +521,24 @@ def test_infant_severity():
     assert "Term_x_Severity2" in results.category_list
 
 
+def test_infant_age():
+    model = CommercialModelV07(year=2024)
+
+    results = model.score(
+        gender="M",
+        metal_level="Silver",
+        csr_indicator=1,
+        enrollment_days=38,
+        diagnosis_codes=[
+            "A0101",
+        ],
+        age=0,
+        verbose=False,
+    )
+    assert "Age1_Male" in results.category_list
+    assert results.risk_model_age == 1
+
+
 def test_interactions():
     model = CommercialModelV07(year=2023)
 

--- a/tests/test_commercial_model_v07.py
+++ b/tests/test_commercial_model_v07.py
@@ -135,6 +135,28 @@ def test_category_groups():
     assert "HHS_HCC183" not in results.category_list
     assert "HHS_HCC183" in results.category_details["G24"]["dropped_categories"]
 
+    # Test that if both 18 and 183 are present, doesn't lead to double counting of
+    # categories
+    results = model.score(
+        gender="M",
+        metal_level="Silver",
+        csr_indicator=1,
+        enrollment_days=365,
+        diagnosis_codes=["B3781", "D84821", "Z9483", "T8610"],
+        age=57,
+        verbose=True,
+    )
+    assert "HHS_HCC006" in results.category_list
+    assert "G08" in results.category_list
+    assert "G24" in results.category_list
+    assert "SEVERE_HCC_COUNT3" in results.category_list
+    assert "HHS_HCC183" not in results.category_list
+    assert "HHS_HCC183" in results.category_details["G24"]["dropped_categories"]
+    assert "HHS_HCC018" not in results.category_list
+    assert "HHS_HCC018" in results.category_details["G24"]["dropped_categories"]
+    assert "HHS_HCC074" not in results.category_list
+    assert "HHS_HCC074" in results.category_details["G08"]["dropped_categories"]
+
     model = CommercialModelV07(year=2025)
     results = model.score(
         gender="M",
@@ -547,6 +569,21 @@ def test_interactions():
     assert "HHS_HCC056" in results.category_list
     assert "HHS_HCC048" in results.category_list
     assert "RXC_09_x_HCC056_057_and_048_041" in results.category_list
+
+    # "RXC_04_x_HCC184_183_187_188"
+    results = model.score(
+        gender="M",
+        metal_level="Silver",
+        csr_indicator=1,
+        enrollment_days=68,
+        diagnosis_codes=["I120"],
+        ndc_codes=["00004040109"],
+        age=54,
+        verbose=False,
+    )
+    assert "G16" in results.category_list
+    assert "HHS_HCC187" not in results.category_list
+    assert "RXC_04_x_HCC184_183_187_188" in results.category_list
 
 
 def test_dropped_categories():

--- a/tests/test_commercial_model_v07.py
+++ b/tests/test_commercial_model_v07.py
@@ -659,3 +659,31 @@ def test_refernce_files_version():
 
     model = CommercialModelV07(year=2025)
     assert "0.0" == model.reference_files_version
+
+
+def test_age_group_categories():
+    model = CommercialModelV07(year=2024)
+
+    results = model.score(
+        gender="M",
+        metal_level="Silver",
+        csr_indicator=1,
+        enrollment_days=365,
+        diagnosis_codes=["I120"],
+        ndc_codes=["00004040109"],
+        age=1,
+        verbose=False,
+    )
+    assert "RXC_04" not in results.category_list
+
+    results = model.score(
+        gender="M",
+        metal_level="Silver",
+        csr_indicator=1,
+        enrollment_days=365,
+        diagnosis_codes=["I120"],
+        ndc_codes=["00004040109"],
+        age=17,
+        verbose=False,
+    )
+    assert "RXC_04" not in results.category_list


### PR DESCRIPTION
This fixes multiple bugs in ACA model discovered through use:

1. Counts are based on groups and categories, but interactions need the categories. So altered code to properly handle it.
2. Fixed the infant risk model age to align with the edge case in the SAS code
3. Fixed the bug where infant and children were getting RXCs if NDCs were passed in, thus causing a failure when trying to get the weight for the category.